### PR TITLE
Fix preg_match() Warning if Filemask/Regex in DOS setting is empty

### DIFF
--- a/dos_class.php
+++ b/dos_class.php
@@ -322,7 +322,7 @@ class DOS {
     $regex_string = $this->filter;
 
     // prepare regex
-    if ( $regex_string == '*' ) {
+    if ( $regex_string == '*' || !strlen($regex_string)) {
       $regex = false;
     } else {
       $regex = preg_match( $regex_string, $file);


### PR DESCRIPTION
Fix preg_match() Warning if Filemask/Regex in DOS setting is empty