### PR TITLE
 Fix empty upload path cause create server real path in DO Space

### DIFF
--- a/dos_class.php
+++ b/dos_class.php
@@ -306,7 +306,8 @@ class DOS {
   // FILE METHODS
   public function file_path ($file) {
 
-    $path = str_replace($this->upload_path, '', $file);
+    $path = strlen($this->upload_path) ? str_replace($this->upload_path, '', $file) 
+                                       : str_replace(wp_upload_dir()['basedir'], '', $file);
   
     return $this->storage_path . $path;
 


### PR DESCRIPTION
$file = "/........./wp-content/uploads/2018/10/picture.jpg"

var_dump($this->upload_path);
string(0) "" 

$path = str_replace($this->upload_path, '', $file);
var_dump($path);
string(102) "/........./wp-content/uploads/2018/10/picture.jpg"

Actual Path created in DO Space
https://space.digitaloceanspace.com/content/........./wp-content/uploads/2018/10/picture.jpg