### PR TITLE
Fix PHP Deprecated warning

### DIFF
--- a/dos_class_filesystem.php
+++ b/dos_class_filesystem.php
@@ -8,7 +8,7 @@ require_once dirname(__FILE__) . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPA
 
 class DOS_Filesystem {
 
-  public function get_instance ( $key, $secret, $container, $endpoint ) {
+  public static function get_instance ( $key, $secret, $container, $endpoint ) {
 
     $client = S3Client::factory([
       'credentials' => [


### PR DESCRIPTION
I got the following error: PHP Deprecated:  Non-static method DOS_Filesystem::get_instance() should not be called statically in /plugins/do-spaces-sync/dos_class.php on line 181
This fix appears to be the solution