### PR TITLE
fix dupe files in delete attachment

### DIFF
--- a/dos_class.php
+++ b/dos_class.php
@@ -227,7 +227,10 @@ class DOS {
       if ( isset($metadata['file']) ) {
 
         $path = $upload_dir['basedir'] . DIRECTORY_SEPARATOR . $metadata['file'];
-        array_push($paths, $path);
+
+        if ( ! in_array($path, $paths) )
+          array_push($paths, $path);
+        }
 
         // set basepath for other sizes
         $file_info = pathinfo($path);


### PR DESCRIPTION
this will fix adding multiple duplicate file names in action_delete_attachment. This will avoid errors when removing duplicate sized filenames.